### PR TITLE
Add support for `id_part` in the metadata to validate the `--ids` option

### DIFF
--- a/src/cli_validator/cmd_meta/parser.py
+++ b/src/cli_validator/cmd_meta/parser.py
@@ -1,6 +1,5 @@
 import argparse
 from typing import NoReturn
-
 from cli_validator.exceptions import ParserHelpException, UnknownTypeException, ParserFailureException
 
 

--- a/src/cli_validator/cmd_meta/parser.py
+++ b/src/cli_validator/cmd_meta/parser.py
@@ -139,8 +139,6 @@ class CLIParser(argparse.ArgumentParser):
                 'default': param.get('default'),
                 'type': self.convert_type(param.get('type')) if param.get('type') else None,
             }
-            if 'required' in param and len(param['options']) > 0:
-                kwargs['required'] = param['required']
             self.add_argument(*param['options'], **kwargs)
 
     def error(self, message: str) -> NoReturn:

--- a/src/cli_validator/cmd_meta/parser.py
+++ b/src/cli_validator/cmd_meta/parser.py
@@ -139,6 +139,7 @@ class CLIParser(argparse.ArgumentParser):
                 'type': self.convert_type(param.get('type')) if param.get('type') else None,
             }
             self.add_argument(*param['options'], **kwargs)
+        self.add_argument('--ids', dest='ids')
 
     def error(self, message: str) -> NoReturn:
         """

--- a/src/cli_validator/cmd_meta/validator.py
+++ b/src/cli_validator/cmd_meta/validator.py
@@ -3,7 +3,6 @@ from cli_validator.cmd_meta.parser import CLIParser
 from cli_validator.cmd_tree import parse_command
 from cli_validator.exceptions import ValidateFailureException
 
-
 class CommandMetaValidator(object):
     """A validator using Command Metadata generated from breaking change tool"""
 

--- a/src/cli_validator/cmd_meta/validator.py
+++ b/src/cli_validator/cmd_meta/validator.py
@@ -1,10 +1,12 @@
 from cli_validator.cmd_meta.loader import load_metas, build_command_tree
 from cli_validator.cmd_meta.parser import CLIParser
 from cli_validator.cmd_tree import parse_command
+from cli_validator.exceptions import ValidateFailureException
 
 
 class CommandMetaValidator(object):
     """A validator using Command Metadata generated from breaking change tool"""
+
     def __init__(self, version: str, cache_dir: str = './cmd_meta'):
         """
         :param version: the version of `azure-cli` that provides the metadata
@@ -26,6 +28,22 @@ class CommandMetaValidator(object):
         parser = self.build_parser(meta)
         namespace = parser.parse_args(cmd.parameters)
 
+        if namespace.ids is not None:
+            for param in meta['parameters']:
+                if 'id_part' in param:
+                    continue
+                else:
+                    if 'required' in param and namespace.__getattribute__(param['name']) is None:
+                        raise ValidateFailureException('Some arguments are required)
+                    else:
+                        continue
+        else:
+            for param in meta['parameters']:
+                if 'required' in param and namespace.__getattribute__(param['name']) is None:
+                    raise ValidateFailureException('Some arguments are required)
+                else:
+                    continue
+
     def load_command_meta(self, signature, module):
         """
         Load metadata of specific command.
@@ -35,8 +53,8 @@ class CommandMetaValidator(object):
         """
         module_meta = self.metas[f'az_{module}_meta.json']
         meta = module_meta
-        for idx in range(len(signature)-1):
-            meta = meta['sub_groups'][' '.join(signature[:idx+1])]
+        for idx in range(len(signature) - 1):
+            meta = meta['sub_groups'][' '.join(signature[:idx + 1])]
         return meta['commands'][' '.join(signature)]
 
     def build_parser(self, meta):

--- a/tests/test_cmd_meta_validator.py
+++ b/tests/test_cmd_meta_validator.py
@@ -13,13 +13,18 @@ class TestCmdChangeValidator(TestCase):
     # Test cases
     def test_validate_correct_command_with_no_ids(self):
         self.validator.validate_command('az storage account show -g qinkai-test -n storageqinkai')
+        
     def test_validate_correct_command_with_ids(self):
         self.validator.validate_command('az storage account show --ids /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/qinkai-test/providers/Microsoft.Storage/storageAccounts/storageqinkai')
+    
     def test_validate_correct_command_with_ids_and_separated_parameter_with_id_part(self):
         self.validator.validate_command('az storage account show --ids /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/qinkai-test/providers/Microsoft.Storage/storageAccounts/storageqinkai -n storageqin')
+    
     def test_validate_correct_command_with_ids_and_required_parameter(self):
         self.validator.validate_command('az webapp create --ids /subscriptions/xxxxx/resourceGroups/xxxxx/xxxxx -p plan-test')
+    
     def test_validate_incorrect_command_with_required_parameters_needed(self):
         self.validator.validate_command('az webapp create --ids /subscriptions/xxxxx/resourceGroups/xxxxx/xxxxx')
+    
     def test_validate_command_without_required_parameters(self):
         self.validator.validate_command('az sig list-community --location myLocation')

--- a/tests/test_cmd_meta_validator.py
+++ b/tests/test_cmd_meta_validator.py
@@ -1,5 +1,4 @@
 from unittest import TestCase
-
 from cli_validator.cmd_meta.validator import CommandMetaValidator
 from cli_validator.exceptions import ParserFailureException, ValidateFailureException
 

--- a/tests/test_cmd_meta_validator.py
+++ b/tests/test_cmd_meta_validator.py
@@ -11,20 +11,20 @@ class TestCmdChangeValidator(TestCase):
 
     # Test cases
     def test_validate_correct_command_with_no_ids(self):
-        self.validator.validate_command('az storage account show -g qinkai-test -n storageqinkai')
+        self.validator.validate_command('az storage account show -g xxxxx -n xxxxx')
         
     def test_validate_correct_command_with_ids(self):
-        self.validator.validate_command('az storage account show --ids /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/qinkai-test/providers/Microsoft.Storage/storageAccounts/storageqinkai')
+        self.validator.validate_command('az storage account show --ids /subscriptions/xxxxx/resourceGroups/xxxxx/providers/xxxxx/storageAccounts/xxxxx')
 
     def test_validate_correct_command_with_ids_and_separated_parameter_with_id_part(self):
-        self.validator.validate_command('az storage account show --ids /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/qinkai-test/providers/Microsoft.Storage/storageAccounts/storageqinkai -n storageqin')
+        self.validator.validate_command('az storage account show --ids /subscriptions/xxxxx/resourceGroups/xxxxx/providers/xxxxx/storageAccounts/xxxxx -n xxxxx')
     
     def test_validate_correct_command_with_ids_and_required_parameter(self):
-        self.validator.validate_command('az webapp create --ids /subscriptions/xxxxx/resourceGroups/xxxxx/xxxxx -p plan-test')
+        self.validator.validate_command('az webapp create --ids /subscriptions/xxxxx/resourceGroups/xxxxx/xxxxx -p xxxxx')
     
     def test_validate_incorrect_command_with_required_parameters_needed(self):
         with self.assertRaises(ValidateFailureException):
             self.validator.validate_command('az webapp create --ids /subscriptions/xxxxx/resourceGroups/xxxxx/xxxxx')
     
     def test_validate_command_without_required_parameters(self):
-        self.validator.validate_command('az sig list-community --location myLocation')
+        self.validator.validate_command('az sig list-community --location xxxxx')

--- a/tests/test_cmd_meta_validator.py
+++ b/tests/test_cmd_meta_validator.py
@@ -15,7 +15,7 @@ class TestCmdChangeValidator(TestCase):
         
     def test_validate_correct_command_with_ids(self):
         self.validator.validate_command('az storage account show --ids /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/qinkai-test/providers/Microsoft.Storage/storageAccounts/storageqinkai')
-    
+
     def test_validate_correct_command_with_ids_and_separated_parameter_with_id_part(self):
         self.validator.validate_command('az storage account show --ids /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/qinkai-test/providers/Microsoft.Storage/storageAccounts/storageqinkai -n storageqin')
     
@@ -23,7 +23,8 @@ class TestCmdChangeValidator(TestCase):
         self.validator.validate_command('az webapp create --ids /subscriptions/xxxxx/resourceGroups/xxxxx/xxxxx -p plan-test')
     
     def test_validate_incorrect_command_with_required_parameters_needed(self):
-        self.validator.validate_command('az webapp create --ids /subscriptions/xxxxx/resourceGroups/xxxxx/xxxxx')
+        with self.assertRaises(ValidateFailureException):
+            self.validator.validate_command('az webapp create --ids /subscriptions/xxxxx/resourceGroups/xxxxx/xxxxx')
     
     def test_validate_command_without_required_parameters(self):
         self.validator.validate_command('az sig list-community --location myLocation')

--- a/tests/test_cmd_meta_validator.py
+++ b/tests/test_cmd_meta_validator.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from cli_validator.cmd_meta.validator import CommandMetaValidator
-from cli_validator.exceptions import ParserFailureException
+from cli_validator.exceptions import ParserFailureException, ValidateFailureException
 
 
 class TestCmdChangeValidator(TestCase):
@@ -10,10 +10,16 @@ class TestCmdChangeValidator(TestCase):
         super().setUp()
         self.validator = CommandMetaValidator('2.50.0', 'test_meta')
 
-    def test_validate_command(self):
-        self.validator.validate_command('az webapp create -g g -n n -p p')
-        self.validator.validate_command('az vm create -n n --resource-group g')
-        with self.assertRaises(ParserFailureException):
-            self.validator.validate_command('az vm create -n n')
-        with self.assertRaises(ParserFailureException):
-            self.validator.validate_command('az vm create -n n -g g --unknown')
+    # Test cases
+    def test_validate_correct_command_with_no_ids(self):
+        self.validator.validate_command('az storage account show -g qinkai-test -n storageqinkai')
+    def test_validate_correct_command_with_ids(self):
+        self.validator.validate_command('az storage account show --ids /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/qinkai-test/providers/Microsoft.Storage/storageAccounts/storageqinkai')
+    def test_validate_correct_command_with_ids_and_separated_parameter_with_id_part(self):
+        self.validator.validate_command('az storage account show --ids /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/qinkai-test/providers/Microsoft.Storage/storageAccounts/storageqinkai -n storageqin')
+    def test_validate_correct_command_with_ids_and_required_parameter(self):
+        self.validator.validate_command('az webapp create --ids /subscriptions/xxxxx/resourceGroups/xxxxx/xxxxx -p plan-test')
+    def test_validate_incorrect_command_with_required_parameters_needed(self):
+        self.validator.validate_command('az webapp create --ids /subscriptions/xxxxx/resourceGroups/xxxxx/xxxxx')
+    def test_validate_command_without_required_parameters(self):
+        self.validator.validate_command('az sig list-community --location myLocation')


### PR DESCRIPTION
New logic which supports special cases has been included in **src/cli_validator/cmd_meta/validator.py#CommandMetaValidator.validate_command**

In the metadata files, where commands and their signatures can be found, there are some parameters that possess a field called **`id_part`**. If a parameter has this field, that means the parameter can be parsed from **`--ids`** and is not required in fact. 

For instance, the following command should be correct because the parameters that contain **`id_part`** are being parsed from **`--ids`**. They do not need to be present after the content of **`--ids`** is complete:

- az storage account show --ids /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/qinkai-test/providers/Microsoft.Storage/storageAccounts/storageqinkai


However, there are some cases where some parameters can be parsed from **`--ids`**, but some others do not possess the **`id_part`**. Therefore, they are **required** and must be present when the user inputs the whole command they are trying to execute:

- az webapp create --ids /subscriptions/xxxxx/resourceGroups/xxxxx/xxxxx -p plan-test


There are some other cases where some commands do not require specific parameters:

- az sig list-community --location myLocation